### PR TITLE
[FEATURE] Better encoder

### DIFF
--- a/src/json2object/utils/TypeTools.hx
+++ b/src/json2object/utils/TypeTools.hx
@@ -38,6 +38,24 @@ class TypeTools {
 
 	#if macro
 
+	public static function isMap(type:Type):Bool {
+		var t = follow(type);
+		switch (t) {
+			case TAbstract(_.get() => a, [keyType, valueType]):
+				if (a.pack.join(".") == "haxe.ds" && a.name == "Map") return true;
+				else return false;
+			
+			case TInst(_.get() => c, [keyType, valueType]):
+				for (i in c.interfaces)
+					if (i.t.get().pack.join(".") == "haxe" && i.t.get().name == "IMap") return true;
+				return false;
+
+			default:
+				return false;
+		}
+	}
+
+
 	public static inline function toComplexType(type:Null<Type>):Null<ComplexType> {
 		return {
 			inline function direct()

--- a/src/json2object/writer/DataBuilder.hx
+++ b/src/json2object/writer/DataBuilder.hx
@@ -272,6 +272,18 @@ class DataBuilder {
 								// You cannot directly compare enums with arguments.
 								// Here, we don't skip the value, and assume @:jcustomparse will handle converting to a primative.
 								defaultSkips.push(macro false);
+							case EArrayDecl(values):
+								var f_shouldskip:Expr = macro $f_a.length == $f_default.length ? {
+									var skip:Bool = true; 
+									for (i in 0...$f_a.length) {
+										if ($f_a[i] != $f_default[i]) {
+											skip = false;
+											break;
+										}
+									}
+									skip;
+								} : false;
+								defaultSkips.push(f_shouldskip);
 							default:
 								// Compare the default value with the value of the field.
 								// If the values are the same, skip the value.


### PR DESCRIPTION
## LINKED ISSUE
https://github.com/FunkinCrew/Funkin/issues/4793

## DESCRIPTION
This pr adds the `:order` metadata for maps. It accepts an array of keys. The writer exports the values in the order of the keys. Any key that isn't in the `:order` metadata will be appended in alphabetical or ascending order (depends on what Reflect.compare does for the type).

When the value is equal to `:default` then it is skipped when exporting.


## EXAMPLE
```haxe
class Data
{
	@:order(["easy", "normal", "hard"])
	public var scores:Map<String, Int>;
        // example
        // keys: "easy", "expert", "nightmare", "normal", "hard"
        // output: "easy", "normal", "hard", "expert", "nightmare"

	@:order([1, 2, 3])
	public var values:Map<Int, Int>;
        // example
        // keys: 1, 3, 5, 2, 4
        // output: 1, 2, 3, 4, 5
}
```