### PR TITLE
Fix now broken formatting of arrays

### DIFF
--- a/src/json2object/writer/DataBuilder.hx
+++ b/src/json2object/writer/DataBuilder.hx
@@ -83,10 +83,14 @@ class DataBuilder {
 				var hasDynamic:Bool = false;
 				for (e in o)
 				{
-					if (Type.typeof(e) == TObject)
+					switch (Type.typeof(e))
 					{
-						hasDynamic = true;
-						break;
+						case TObject | TClass(_) | TEnum(_):
+						{
+							hasDynamic = true;
+							break;
+						}
+						case _:
 					}
 				}
 


### PR DESCRIPTION
Makes it so classes and enums are also considered dynamics/structures so they don't get oddly formatted like in https://github.com/FunkinCrew/json2object/pull/1#issuecomment-3386583325